### PR TITLE
Fix typo in Init method documentation

### DIFF
--- a/source/application/api/common/include/Model.hpp
+++ b/source/application/api/common/include/Model.hpp
@@ -63,8 +63,8 @@ namespace app {
         void LogInterpreterInfo();
 
         /** @brief      Initialise the model class object.
-         *  @param[in]  tensorArenaAddress  Pointer to the tensor arena buffer.
-         *  @param[in]  tensorArenaAddress  Size of the tensor arena buffer in bytes.
+         *  @param[in]  tensorArenaAddr     Pointer to the tensor arena buffer.
+         *  @param[in]  tensorArenaSize     Size of the tensor arena buffer in bytes.
          *  @param[in]  nnModelAddr         Pointer to the model.
          *  @param[in]  nnModelSize         Size of the model in bytes, if known.
          *  @param[in]  allocator   Optional: a pre-initialised micro allocator pointer,


### PR DESCRIPTION

<img width="1552" alt="Screenshot 2024-09-09 at 10 57 19 PM" src="https://github.com/user-attachments/assets/615a5d2e-fe66-4940-903e-25dff5416af9">

corrected `tensorArenaAddress` to `tensorArenaAddr` and the second `tensorArenaAddress` to `tensorArenaSize` for clarity. This resolves the typo and ensures the parameter names accurately describe their purpose.