### PR TITLE
Updates and fixes

### DIFF
--- a/resources/use_case_resources.json
+++ b/resources/use_case_resources.json
@@ -108,12 +108,12 @@
   {
     "name": "object_detection",
     "url_prefix": [
-      "https://github.com/emza-vs/ModelZoo/blob/v1.0/object_detection/"
+      "https://github.com/emza-vs/ModelZoo/raw/refs/tags/v1.0/object_detection/"
     ],
     "resources": [
       {
         "name": "yolo-fastest_192_face_v4.tflite",
-        "url": "{url_prefix:0}yolo-fastest_192_face_v4.tflite?raw=true"
+        "url": "{url_prefix:0}yolo-fastest_192_face_v4.tflite"
       }
     ]
   },

--- a/source/hal/source/components/audio_alif/source/alif/audio_alif.c
+++ b/source/hal/source/components/audio_alif/source/alif/audio_alif.c
@@ -221,7 +221,7 @@ static void voice_data_cb(uint32_t event)
     if (new_total < user_length) {
         audio_start_next_rx(user_length - new_total);
     } else if (new_total > user_length) {
-        samples = new_total - user_length;
+        samples = user_length - audio_received;
         new_total = user_length;
     }
 #ifdef STORE_AUDIO

--- a/source/hal/source/components/audio_alif/source/alif/mic_listener.c
+++ b/source/hal/source/components/audio_alif/source/alif/mic_listener.c
@@ -160,7 +160,7 @@ static void PDM_fifo_callback(uint32_t event)
 }
 
 /* PDM driver instance */
-#if defined(RTE_LPPDM)
+#if defined(BOARD_LPPDM_ENABLED) && (BOARD_LPPDM_ENABLED == 1)
 extern ARM_DRIVER_PDM Driver_LPPDM;
 static ARM_DRIVER_PDM* const PDMdrv = &Driver_LPPDM;
 #else

--- a/source/hal/source/platform/alif/cmsis-pack/Boards/AppKit-e8/board_defs.h
+++ b/source/hal/source/platform/alif/cmsis-pack/Boards/AppKit-e8/board_defs.h
@@ -119,7 +119,7 @@
 // </e>
 
 // <e> LPPDM module enabled flag
-#define BOARD_LPPDM_ENABLED                             1
+#define BOARD_LPPDM_ENABLED                             0
 // </e>
 
 // <e> MISC module enabled flag

--- a/source/hal/source/platform/alif/cmsis-pack/Boards/DevKit-e4/board_defs.h
+++ b/source/hal/source/platform/alif/cmsis-pack/Boards/DevKit-e4/board_defs.h
@@ -150,7 +150,7 @@
 // </e>
 
 // <e> LPPDM module enabled flag
-#define BOARD_LPPDM_ENABLED                             1
+#define BOARD_LPPDM_ENABLED                             0
 // </e>
 
 // <e> MISC module enabled flag

--- a/source/hal/source/platform/alif/cmsis-pack/Boards/DevKit-e7/board_defs.h
+++ b/source/hal/source/platform/alif/cmsis-pack/Boards/DevKit-e7/board_defs.h
@@ -147,7 +147,7 @@
 // </e>
 
 // <e> LPPDM module enabled flag
-#define BOARD_LPPDM_ENABLED                             1
+#define BOARD_LPPDM_ENABLED                             0
 // </e>
 
 // <e> MISC module enabled flag

--- a/source/hal/source/platform/alif/cmsis-pack/Boards/DevKit-e8/board_defs.h
+++ b/source/hal/source/platform/alif/cmsis-pack/Boards/DevKit-e8/board_defs.h
@@ -155,7 +155,7 @@
 // </e>
 
 // <e> LPPDM module enabled flag
-#define BOARD_LPPDM_ENABLED                             1
+#define BOARD_LPPDM_ENABLED                             0
 // </e>
 
 // <e> MISC module enabled flag


### PR DESCRIPTION
This pull request primarily disables the LPPDM (Low Power PDM microphone) module by default across multiple board configuration files and updates a few resource and callback implementations. The main themes are configuration changes for board support and minor logic corrections in audio processing and resource URLs.

**Board Configuration Updates:**

* Disabled the LPPDM module by default (`BOARD_LPPDM_ENABLED` set to `0`) in the following board definition files: `AppKit-e8/board_defs.h`, `DevKit-e4/board_defs.h`, `DevKit-e7/board_defs.h`, and `DevKit-e8/board_defs.h`. This ensures the LPPDM feature is off unless explicitly enabled. [[1]](diffhunk://#diff-792588871dc7835491c3e9c193a471ea08ae8da4c2697d1fe216e506613b1265L122-R122) [[2]](diffhunk://#diff-d649afa361d09a366f084a700f3397bd3b247f1fe7e2beb2f6d93d84ab5ec2c7L153-R153) [[3]](diffhunk://#diff-02988b6d69cc9b97549cc27684be963764b6c020cece9bbe6e851abaa0167590L150-R150) [[4]](diffhunk://#diff-4f60a015798462d5d6aadd7359be801278abf7edf74a91ff92e3a27d74c8c545L158-R158)

**Audio Driver Logic and Resource Updates:**

* Updated the conditional compilation in `mic_listener.c` to use `BOARD_LPPDM_ENABLED` instead of `RTE_LPPDM`, ensuring the correct driver is included based on the new board configuration flag.
* Fixed the calculation of the `samples` variable in `audio_alif.c` to correctly compute the number of remaining samples to process, preventing potential buffer overruns or underruns.

**Resource URL Correction:**

* Updated the `object_detection` resource URL in `use_case_resources.json` to use the raw GitHub tag reference and removed the redundant `?raw=true` query parameter, ensuring correct and direct access to the TFLite model file.