### PR TITLE
Zephyr asr support

### DIFF
--- a/scripts/py/mlek_tools/setup/resources.py
+++ b/scripts/py/mlek_tools/setup/resources.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 import sys
 import typing
 from pathlib import Path
@@ -256,6 +257,91 @@ def install_executorch(executorch_path: Path, python_env: PythonEnv) -> None:
         env=env,
     )
 
+    # The Arm/Cortex-M backend (used by aot_arm_compiler for the Ethos-U delegate)
+    # needs extra deps (e.g. cmsis_nn) that install_executorch.sh does not pull in.
+    cortex_m_requirements = (
+        executorch_path / 'backends' / 'cortex_m' / 'requirements-cortex-m.txt'
+    )
+    if cortex_m_requirements.is_file():
+        install_cortex_m_deps(cortex_m_requirements, python_env)
+
+
+def install_cortex_m_deps(
+        requirements_file: Path,
+        python_env: PythonEnv,
+) -> None:
+    """
+    Install the ExecuTorch Cortex-M backend Python dependencies (e.g. cmsis_nn).
+
+    Versions are taken from ``requirements-cortex-m.txt`` (shipped with the
+    ExecuTorch source), not hardcoded here. We first attempt the upstream install
+    path (build isolation, matching examples/arm/setup.sh). Only if that fails do
+    we apply a workaround: the CMSIS-NN commit currently pinned by ExecuTorch still
+    uses the deprecated ``cmake.minimum-version`` key, which scikit-build-core >= 0.8
+    rejects, and pip's build isolation always pulls the latest scikit-build-core.
+    The fallback provides a compatible build backend (< 0.8) in the venv and
+    disables build isolation. Once the pinned CMSIS-NN is fixed upstream, the first
+    attempt succeeds and the fallback is never used.
+
+    :param requirements_file:   Path to requirements-cortex-m.txt.
+    :param python_env:          The Python virtual environment.
+    """
+    try:
+        python_env.pip_install_requirements(requirements_file, no_deps=True)
+        return
+    except subprocess.CalledProcessError:
+        logging.warning(
+            "Cortex-M deps install failed with build isolation; retrying with a "
+            "pinned scikit-build-core (< 0.8) and no build isolation. This works "
+            "around the deprecated cmake.minimum-version key in the CMSIS-NN "
+            "commit pinned by ExecuTorch."
+        )
+
+    python_env.pip_install('"scikit-build-core[pyproject]<0.8" "pybind11>=2.10"')
+    call_command(
+        f'"{python_env.python}" -m pip install --no-build-isolation --no-deps '
+        f'-r {requirements_file}'
+    )
+
+
+def executorch_install_matches_source(
+        executorch_path: Path,
+        python_env: PythonEnv,
+) -> bool:
+    """
+    Check whether the ExecuTorch installed in the venv matches the source tree.
+
+    Compares the git revision recorded in the installed ``executorch`` package
+    against the current HEAD of the source checkout at ``executorch_path``. This
+    catches the case where the venv still holds an ExecuTorch built from a
+    different checkout (e.g. after switching ``--executorch-path``), which would
+    otherwise cause import errors for modules added in the newer source.
+
+    :param executorch_path: Root of the ExecuTorch source tree.
+    :param python_env:      The Python virtual environment.
+    :return:                True if the installed revision matches the source HEAD,
+                            or if the comparison cannot be made (to avoid forcing an
+                            unnecessary reinstall); False on a confirmed mismatch.
+    """
+    try:
+        source_rev = subprocess.run(
+            ['git', '-C', str(executorch_path), 'rev-parse', 'HEAD'],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return True
+
+    installed_rev = subprocess.run(
+        [str(python_env.python), '-c',
+         'import executorch.version as v; print(v.git_version)'],
+        capture_output=True, text=True, check=False,
+    ).stdout.strip()
+
+    if not source_rev or not installed_rev:
+        return True
+
+    return installed_rev == source_rev
+
 
 def optimize_executorch_model(
         model_name: typing.Union[str, Path],
@@ -345,7 +431,12 @@ def setup_executorch(
     python_env = setup_context.python_env
     executorch_path = setup_context.paths_config.executorch_path
 
-    if not python_env.is_installed("executorch"):
+    if (not python_env.is_installed("executorch")
+            or not executorch_install_matches_source(executorch_path, python_env)):
+        logging.info(
+            "Installing ExecuTorch from %s into the virtual environment.",
+            executorch_path,
+        )
         install_executorch(executorch_path, python_env)
 
 

--- a/set_up_default_resources.py
+++ b/set_up_default_resources.py
@@ -235,6 +235,12 @@ if __name__ == "__main__":
         default=default_downloads_path,
     )
     parser.add_argument(
+        "--executorch-path",
+        help="Path to the root of the ExecuTorch source tree",
+        type=Path,
+        default=default_executorch_path,
+    )
+    parser.add_argument(
         "--http-header",
         help="Specify HTTP Headers to set when downloading from a domain. "
              "Example: --http-header my-internal-website.com 'Authorization: Bearer $TOKEN'",
@@ -284,7 +290,7 @@ if __name__ == "__main__":
         use_case_resources_files=use_case_resources_files,
         downloads_dir=parsed_args.downloads_dir,
         additional_requirements_file=parsed_args.requirements_file,
-        executorch_path=default_executorch_path,
+        executorch_path=parsed_args.executorch_path,
         vela_config_file=_default_vela_config_file,
     )
 

--- a/source/lib/mlek/fwk/executorch/CMakeLists.txt
+++ b/source/lib/mlek/fwk/executorch/CMakeLists.txt
@@ -57,6 +57,15 @@ target_link_libraries(${ML_FWK_ET_TARGET} PUBLIC
     mlek::ml_framework_iface                                    # ML framework interface lib
     $<$<NOT:$<BOOL:${CMSIS_PACK_GEN_FLOW}>>:meta::executorch>)  # ExecuTorch libraries
 
+# The Zephyr ExecuTorch module links program_schema PRIVATE into
+# executorch_core, so the generated flatbuffer schema headers
+# (executorch/schema/program_generated.h) and the bundled flatbuffers headers
+# are not propagated through meta::executorch. EtModel.cc includes them
+# directly, so link the INTERFACE schema target to pull in its include dirs.
+if (NOT CMSIS_PACK_GEN_FLOW AND TARGET program_schema)
+    target_link_libraries(${ML_FWK_ET_TARGET} PRIVATE program_schema)
+endif()
+
 target_compile_definitions(${ML_FWK_ET_TARGET} INTERFACE
     MLEK_FWK_EXECUTORCH=1)
 

--- a/source/lib/mlek/fwk/executorch/EtModel.cc
+++ b/source/lib/mlek/fwk/executorch/EtModel.cc
@@ -63,6 +63,7 @@ bool ContainsSubstring(const char* str, const char* substr)
  * @param[in] size  Size of the PTE buffer in bytes.
  * @return Memory mode string if found, or empty string otherwise.
  */
+#if defined(MLEK_LOG_ENABLE)
 std::string ParsePteMemoryMode(const uint8_t* data, size_t size)
 {
     if (!data || size == 0) {
@@ -97,6 +98,7 @@ std::string ParsePteMemoryMode(const uint8_t* data, size_t size)
 
     return {};
 }
+#endif /* defined(MLEK_LOG_ENABLE) */
 } /* anonymous namespace */
 
 EtModel::EtModel()
@@ -416,6 +418,8 @@ void EtModel::LogOperatorInfo()
     }
 
     if (this->m_hasEthosUDelegate) {
+#if defined(MLEK_LOG_ENABLE)
+        // Scans the whole PTE (in slow XIP flash); only worth it when the result is logged.
         const auto* data = static_cast<const uint8_t*>(this->m_modelBuffer.data);
         const std::string mode = ParsePteMemoryMode(data, this->m_modelBuffer.size);
         if (!mode.empty()) {
@@ -423,6 +427,7 @@ void EtModel::LogOperatorInfo()
         } else {
             warn("Unable to infer NPU memory mode.\n");
         }
+#endif /* MLEK_LOG_ENABLE */
     }
 }
 

--- a/source/lib/ports/zephyr/CMakeLists.txt
+++ b/source/lib/ports/zephyr/CMakeLists.txt
@@ -45,10 +45,15 @@ if (CONFIG_MLEK_EXAMPLES_FWK_EXECUTORCH)
         mlek_config_err(CONFIG_EXECUTORCH)
     endif()
 
-    if (TARGET modules__executorch)
+    # The Zephyr ExecuTorch module names its library target explicitly with
+    # zephyr_library_named(libexecutorch), so the default "modules__executorch"
+    # target does not exist. Support both names for robustness.
+    if (TARGET libexecutorch)
+        add_library(meta::executorch ALIAS libexecutorch)
+    elseif (TARGET modules__executorch)
         add_library(meta::executorch ALIAS modules__executorch)
     else()
-        message(FATAL_ERROR "Target modules__executorch not found.")
+        message(FATAL_ERROR "Neither target 'libexecutorch' nor 'modules__executorch' found.")
     endif()
 elseif (CONFIG_MLEK_EXAMPLES_FWK_TFLM)
     set(ML_FRAMEWORK "TensorFlowLiteMicro")


### PR DESCRIPTION
- Modifications to get executorch ASR UC working on Zephyr.
ASR UC uses Zephyr's version of executorch. This PR changes makes it possible to use other executorch than dependencies/executorch.
- scanning the executorch in ASR UC takes ~8 seconds so made it conditional under the MLEK_LOG_ENABLE flag as scanning result is only used then.